### PR TITLE
add mod_auth config hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ one:
 
     server.modules = (
       # …
+      "
+      "mod_auth",
       "mod_webdav",
     )
 


### PR DESCRIPTION
mod_auth is not included in the default lighttpd config and needs to be added manually. Add the line to the code example so people don’t have to dig in the error.log file to find out why it isn’t working.
