### PR TITLE
give share activity a proper name

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -4,6 +4,6 @@
     <string name="app_name">DavSync</string>
     <string name="action_settings">DavSync Settings</string>
     <string name="hello_world">Hello world!</string>
-    <string name="title_activity_share">ShareActivity</string>
+    <string name="title_activity_share">Share via DavSync</string>
 
 </resources>


### PR DESCRIPTION
The string is used when viewing a picture in the gallery and using the "show all share options" list.
