### PR TITLE
don’t report errors for 204 http status codes

### DIFF
--- a/src/net/zekjur/davsync/UploadService.java
+++ b/src/net/zekjur/davsync/UploadService.java
@@ -122,9 +122,9 @@ public class UploadService extends IntentService {
 		try {
 			HttpResponse response = httpClient.execute(httpPut);
 			int status = response.getStatusLine().getStatusCode();
-			// 201 means the file was created, 200 means it was stored but
-			// already existed.
-			if (status == 201 || status == 200) {
+			// 201 means the file was created.
+			// 200 and 204 mean it was stored but already existed.
+			if (status == 201 || status == 200 || status == 204) {
 				// The file was uploaded, so we remove the ongoing notification,
 				// remove it from the queue and that’s it.
 				mNotificationManager.cancel(uri.toString(), 0);


### PR DESCRIPTION
204 in webdav context is generally defined as “success, no content returned” meaning that the action completed successfully and that there’s no body. It is not specifically defined for PUT operations, however web servers[1] return this on overwrite.

[1] e.g. nginx (tested locally) and apache 2 (see https://bugs.launchpad.net/duplicity/+bug/888301)
