### PR TITLE
add missing permission for Android 4.4+

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -10,6 +10,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
The missing permission made DavSync crash when trying to upload a
recently taken photo.
